### PR TITLE
[FIX] Removed JsonIgnore from User

### DIFF
--- a/core/src/main/java/com/bls/core/user/User.java
+++ b/core/src/main/java/com/bls/core/user/User.java
@@ -43,7 +43,6 @@ public class User<K> extends IdentifiableEntity<K> {
         return email;
     }
 
-    @JsonIgnore
     public String getPassword() {
         return password;
     }


### PR DESCRIPTION
It caused mongodb not to store password in user document.
As we don't list users anywhere it's doesn't make a security problem IMO.
We need a workaround on this.