### PR TITLE
Fix for NPE on authentication with incomplete user data

### DIFF
--- a/api/src/main/java/com/bls/auth/basic/BasicAuthenticator.java
+++ b/api/src/main/java/com/bls/auth/basic/BasicAuthenticator.java
@@ -12,6 +12,7 @@ import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.hibernate.UnitOfWork;
 
 import static com.bls.AugmentedConfiguration.PW_HASH_SECURITY_LEVEL;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Basic Authenticator class using plaintext credentials
@@ -40,8 +41,14 @@ public class BasicAuthenticator implements Authenticator<BasicCredentials, User>
         String plaintextPassword = basicCredentials.getPassword();
 
         final Optional<User> user = userDao.findByEmail(email);
-        if (user.isPresent() && isMatched(plaintextPassword, user.get().getPassword())) {
-            return user;
+        if (user.isPresent()) {
+            final User existingUser = user.get();
+            checkState(existingUser.getPassword() != null, "Cannot authenticate: user with id: %s (email: %s) without password",
+                    existingUser.getId(), existingUser.getEmail());
+
+            if (isMatched(plaintextPassword, existingUser.getPassword())) {
+                return user;
+            }
         }
         return Optional.absent();
     }


### PR DESCRIPTION
```
ERROR [2015-06-03 11:19:28,185] io.dropwizard.jersey.errors.LoggingExceptionMapper: Error handling a request: 8b004e6ec95c7193! java.lang.NullPointerException: null!
at org.mindrot.jbcrypt.BCrypt.hashpw(BCrypt.java:663) ~[augumented-api.jar:1.0.0-SNAPSHOT]!
at org.mindrot.jbcrypt.BCrypt.checkpw(BCrypt.java:763) ~[augumented-api.jar:1.0.0-SNAPSHOT]!
at com.bls.auth.basic.BasicAuthenticator.isMatched(BasicAuthenticator.java:33) ~[augumented-api.jar:1.0.0-SNAPSHOT]!
at com.bls.auth.basic.BasicAuthenticator.authenticate(BasicAuthenticator.java:43) ~[augumented-api.jar:1.0.0-SNAPSHOT]!
at com.bls.auth.basic.BasicAuthenticator.authenticate(BasicAuthenticator.java:22) ~[augumented-api.jar:1.0.0-SNAPSHOT]
```